### PR TITLE
Add WM-track single-view GE-Sim training support

### DIFF
--- a/configs/cosmos_model/acwm_cosmos.yaml
+++ b/configs/cosmos_model/acwm_cosmos.yaml
@@ -59,7 +59,7 @@ diffusion_model:
   model_path: LOCAL_PATH/TO/ge_sim_cosmos_v0.1.safetensors
 
   config:
-    in_channels: 26  # 16 (vae) + 3 (traj) + 6 (raymap) + 1 (padding mask)
+    in_channels: 26  # 16 (vae) + 3 (traj) + 6 (raymap) + 1 (condition mask); padding_mask is appended inside the transformer
     out_channels: 16
     num_attention_heads: 16
     attention_head_dim: 128

--- a/configs/cosmos_model/acwm_cosmos_challenge_wm_singleview.yaml
+++ b/configs/cosmos_model/acwm_cosmos_challenge_wm_singleview.yaml
@@ -1,0 +1,173 @@
+model_name: 'gesim_challenge_wm_train'
+is_i2v: True
+report_to: None
+tracker_name: gesim_challenge_wm_trainer
+
+logging_dir: logs
+output_dir: PATH_TO_SAVE_LOGS_AND_CHECKPOINTS
+pretrained_model_name_or_path: PATH_TO_PRETRAINED_WEIGHTS_OF_VAE_AND_TOKENIZER
+tokenizer_pretrained_model_name_or_path: PATH_TO_PRETRAINED_WEIGHTS_OF_VAE_AND_TOKENIZER
+
+###
+train_data_class_path: data/challenge_wm_dataset.py
+train_data_class: ChallengeWMDataset
+val_data_class_path: data/challenge_wm_dataset.py
+val_data_class: ChallengeWMDataset
+
+###
+tokenizer_class_path: transformers
+tokenizer_class: T5TokenizerFast
+textenc_class_path: transformers
+textenc_class: T5EncoderModel
+vae_class_path: models/cosmos_models/models/autoencoders/autoencoder_kl_wan.py
+vae_class: AutoencoderKLWan
+diffusion_model_class_path: models/cosmos_models/models/transformers/transformer_cosmos_multiview.py
+diffusion_model_class: MultiViewCosmosTransformer3DModel
+diffusion_scheduler_class_path: models/pipeline/gesim_cosmos2_pipeline_utils/scheduling_flow_match_euler_discrete.py
+diffusion_scheduler_class: FlowMatchEulerDiscreteScheduler
+
+pipeline_class_path: models/pipeline/gesim_pipeline.py
+pipeline_class: GeSimCosmos2Pipeline
+
+#
+return_action: false
+return_video: true
+train_mode: 'video_only'
+action_loss_scale: 1.0
+action_cond_mode: true
+use_geom_condition: true   # requires trainer to pass batch['cond_to_concat'] into GE-Sim forward
+geom_condition_key: cond_to_concat
+
+# total training step is decided by the minimum of the below two
+train_steps: 300000
+train_epochs: 10000
+steps_to_save: 5000
+steps_to_log: 20
+steps_to_val: 5000
+
+mixed_precision: bf16
+allow_tf32: False
+
+# timeout, seconds
+nccl_timeout: 600
+seed: 42
+
+# vae
+enable_slicing: True
+enable_tiling: True
+
+add_state: False
+
+caption_dropout_p: 0.0
+
+# dataloader
+batch_size: 2
+dataloader_num_workers: 4
+pin_memory: True
+
+gradient_checkpointing: True
+noise_to_first_frame: 0.0
+
+# Optimizer Config
+optimizer: adamw
+lr: 1e-5
+beta1: 0.9
+beta2: 0.95
+beta3: 0.999
+epsilon: 1e-8
+weight_decay: 1e-5
+optimizer_8bit: False
+optimizer_torchao: False
+scale_lr: False
+
+max_grad_norm: 1.0
+gradient_accumulation_steps: 1
+
+# lr_scheduler Config
+lr_scheduler: constant_with_warmup
+lr_warmup_steps: 1000
+lr_num_cycles: 1
+lr_power: 1.0
+
+# Timestep Config
+flow_weighting_scheme: none
+flow_logit_mean: 0.0
+flow_logit_std: 1.0
+flow_mode_scale: 1.29
+
+pixel_wise_timestep: False
+
+diffusion_model:
+  model_path: PATH_TO_GE_SIM_COSMOS_CHECKPOINT_SAFETENSOR
+  config:
+    in_channels: 26  # 16 (vae latent) + 3 (traj) + 6 (raymap) + 1 (condition mask); padding_mask is appended inside the transformer
+    out_channels: 16
+    num_attention_heads: 16
+    attention_head_dim: 128
+    num_layers: 28
+    mlp_ratio: 4.0
+    text_embed_dim: 1024
+    adaln_lora_dim: 256
+    max_size: [128, 240, 240]
+    patch_size: [1, 2, 2]
+    rope_scale: [1.0, 3.0, 3.0]
+    concat_padding_mask: true
+    extra_pos_embed_type: null
+    use_view_embed: true
+    action_expert: false
+    action_in_channels: 7
+    action_num_attention_heads: 16
+    action_attention_head_dim: 32
+    action_rope_dim: 32
+
+data:
+  train:
+    data_roots: ["path/to/AgiBotWorldChallenge-2026/WorldModel"]
+    domains: ["agibotworld"]
+    split: "train"
+    sample_size: [320, 512]
+    sample_n_frames: 64
+    preprocess: 'resize'
+    valid_cam: ['head']
+    chunk: 16
+    action_chunk: 16
+    n_previous: 4
+    previous_pick_mode: 'random'
+    random_crop: True
+    min_sep: 1
+    max_sep: 3
+    dataset_info_cache_path: null
+    use_unified_prompt: True
+    unified_prompt: "best quality, consistent and smooth motion, realistic, clear and distinct."
+    action_space: "eef"
+    normalize_actions: False
+  val:
+    data_roots: ["path/to/AgiBotWorldChallenge-2026/WorldModel"]
+    domains: ["agibotworld"]
+    split: "val"
+    sample_size: [320, 512]
+    sample_n_frames: 64
+    preprocess: 'resize'
+    valid_cam: ['head']
+    chunk: 16
+    action_chunk: 16
+    n_previous: 4
+    previous_pick_mode: 'random'
+    random_crop: False
+    min_sep: 1
+    max_sep: 1
+    dataset_info_cache_path: null
+    use_unified_prompt: True
+    unified_prompt: "best quality, consistent and smooth motion, realistic, clear and distinct."
+    action_space: "eef"
+    normalize_actions: False
+
+use_color_jitter: false
+num_inference_step: 15
+noisy_video: false
+
+# false for quick debug, true for initialization from released GE-Sim weights
+load_weights: true
+
+# current default is torchrun + accelerate DDP; multi-node is supported through scripts/train.sh
+use_deepspeed: false

--- a/configs/cosmos_model/acwm_cosmos_challenge_wm_singleview_debug.yaml
+++ b/configs/cosmos_model/acwm_cosmos_challenge_wm_singleview_debug.yaml
@@ -1,0 +1,152 @@
+model_name: 'gesim_challenge_wm_debug'
+is_i2v: True
+report_to: None
+tracker_name: gesim_challenge_wm_debug
+
+logging_dir: logs
+output_dir: PATH_TO_SAVE_LOGS_AND_CHECKPOINTS
+sub_folder: debug_smoke
+pretrained_model_name_or_path: PATH_TO_PRETRAINED_WEIGHTS_OF_VAE_AND_TOKENIZER
+tokenizer_pretrained_model_name_or_path: PATH_TO_PRETRAINED_WEIGHTS_OF_VAE_AND_TOKENIZER
+
+train_data_class_path: data/challenge_wm_dataset.py
+train_data_class: ChallengeWMDataset
+val_data_class_path: data/challenge_wm_dataset.py
+val_data_class: ChallengeWMDataset
+
+tokenizer_class_path: transformers
+tokenizer_class: T5TokenizerFast
+textenc_class_path: transformers
+textenc_class: T5EncoderModel
+vae_class_path: models/cosmos_models/models/autoencoders/autoencoder_kl_wan.py
+vae_class: AutoencoderKLWan
+diffusion_model_class_path: models/cosmos_models/models/transformers/transformer_cosmos_multiview.py
+diffusion_model_class: MultiViewCosmosTransformer3DModel
+diffusion_scheduler_class_path: models/pipeline/gesim_cosmos2_pipeline_utils/scheduling_flow_match_euler_discrete.py
+diffusion_scheduler_class: FlowMatchEulerDiscreteScheduler
+pipeline_class_path: models/pipeline/gesim_pipeline.py
+pipeline_class: GeSimCosmos2Pipeline
+
+return_action: false
+return_video: true
+train_mode: 'video_only'
+action_loss_scale: 1.0
+action_cond_mode: true
+use_geom_condition: true
+geom_condition_key: cond_to_concat
+
+train_steps: 20
+train_epochs: 1
+steps_to_save: 10
+steps_to_log: 1
+steps_to_val: 10
+
+mixed_precision: bf16
+allow_tf32: False
+nccl_timeout: 600
+seed: 42
+enable_slicing: True
+enable_tiling: True
+add_state: False
+caption_dropout_p: 0.0
+
+batch_size: 1
+dataloader_num_workers: 0
+pin_memory: True
+gradient_checkpointing: True
+noise_to_first_frame: 0.0
+
+optimizer: adamw
+lr: 1e-5
+beta1: 0.9
+beta2: 0.95
+beta3: 0.999
+epsilon: 1e-8
+weight_decay: 1e-5
+optimizer_8bit: False
+optimizer_torchao: False
+scale_lr: False
+max_grad_norm: 1.0
+gradient_accumulation_steps: 1
+
+lr_scheduler: constant_with_warmup
+lr_warmup_steps: 1
+lr_num_cycles: 1
+lr_power: 1.0
+
+flow_weighting_scheme: none
+flow_logit_mean: 0.0
+flow_logit_std: 1.0
+flow_mode_scale: 1.29
+pixel_wise_timestep: False
+
+diffusion_model:
+  model_path: PATH_TO_GE_SIM_COSMOS_CHECKPOINT_SAFETENSOR
+  config:
+    in_channels: 26  # 16 (vae latent) + 3 (traj) + 6 (raymap) + 1 (condition mask); padding_mask is appended inside the transformer
+    out_channels: 16
+    num_attention_heads: 16
+    attention_head_dim: 128
+    num_layers: 28
+    mlp_ratio: 4.0
+    text_embed_dim: 1024
+    adaln_lora_dim: 256
+    max_size: [128, 240, 240]
+    patch_size: [1, 2, 2]
+    rope_scale: [1.0, 3.0, 3.0]
+    concat_padding_mask: true
+    extra_pos_embed_type: null
+    use_view_embed: true
+    action_expert: false
+    action_in_channels: 7
+    action_num_attention_heads: 16
+    action_attention_head_dim: 32
+    action_rope_dim: 32
+
+data:
+  train:
+    data_roots: ["path/to/AgiBotWorldChallenge-2026/WorldModel"]
+    domains: ["agibotworld"]
+    split: "train"
+    sample_size: [320, 512]
+    sample_n_frames: 20
+    preprocess: 'resize'
+    valid_cam: ['head']
+    chunk: 16
+    action_chunk: 16
+    n_previous: 4
+    previous_pick_mode: 'random'
+    random_crop: False
+    min_sep: 1
+    max_sep: 1
+    dataset_info_cache_path: null
+    use_unified_prompt: True
+    unified_prompt: "best quality, consistent and smooth motion, realistic, clear and distinct."
+    action_space: "eef"
+    normalize_actions: False
+  val:
+    data_roots: ["path/to/AgiBotWorldChallenge-2026/WorldModel"]
+    domains: ["agibotworld"]
+    split: "train"
+    sample_size: [320, 512]
+    sample_n_frames: 20
+    preprocess: 'resize'
+    valid_cam: ['head']
+    chunk: 16
+    action_chunk: 16
+    n_previous: 4
+    previous_pick_mode: 'random'
+    random_crop: False
+    min_sep: 1
+    max_sep: 1
+    dataset_info_cache_path: null
+    use_unified_prompt: True
+    unified_prompt: "best quality, consistent and smooth motion, realistic, clear and distinct."
+    action_space: "eef"
+    normalize_actions: False
+
+use_color_jitter: false
+num_inference_step: 5
+noisy_video: false
+load_weights: true
+use_deepspeed: false

--- a/configs/cosmos_model/acwm_cosmos_challenge_wm_singleview_overfit.yaml
+++ b/configs/cosmos_model/acwm_cosmos_challenge_wm_singleview_overfit.yaml
@@ -1,0 +1,158 @@
+model_name: 'gesim_challenge_wm_overfit'
+is_i2v: True
+report_to: None
+tracker_name: gesim_challenge_wm_overfit
+
+logging_dir: logs
+output_dir: PATH_TO_SAVE_LOGS_AND_CHECKPOINTS
+sub_folder: debug_overfit_one_sample
+pretrained_model_name_or_path: PATH_TO_PRETRAINED_WEIGHTS_OF_VAE_AND_TOKENIZER
+tokenizer_pretrained_model_name_or_path: PATH_TO_PRETRAINED_WEIGHTS_OF_VAE_AND_TOKENIZER
+
+train_data_class_path: data/challenge_wm_dataset.py
+train_data_class: ChallengeWMDataset
+val_data_class_path: data/challenge_wm_dataset.py
+val_data_class: ChallengeWMDataset
+
+tokenizer_class_path: transformers
+tokenizer_class: T5TokenizerFast
+textenc_class_path: transformers
+textenc_class: T5EncoderModel
+vae_class_path: models/cosmos_models/models/autoencoders/autoencoder_kl_wan.py
+vae_class: AutoencoderKLWan
+diffusion_model_class_path: models/cosmos_models/models/transformers/transformer_cosmos_multiview.py
+diffusion_model_class: MultiViewCosmosTransformer3DModel
+diffusion_scheduler_class_path: models/pipeline/gesim_cosmos2_pipeline_utils/scheduling_flow_match_euler_discrete.py
+diffusion_scheduler_class: FlowMatchEulerDiscreteScheduler
+pipeline_class_path: models/pipeline/gesim_pipeline.py
+pipeline_class: GeSimCosmos2Pipeline
+
+return_action: false
+return_video: true
+train_mode: 'video_only'
+action_loss_scale: 1.0
+action_cond_mode: true
+use_geom_condition: true
+geom_condition_key: cond_to_concat
+
+train_steps: 200
+train_epochs: 100
+steps_to_save: 50
+steps_to_log: 1
+steps_to_val: 50
+
+mixed_precision: bf16
+allow_tf32: False
+nccl_timeout: 600
+seed: 42
+enable_slicing: True
+enable_tiling: True
+add_state: False
+caption_dropout_p: 0.0
+
+batch_size: 1
+dataloader_num_workers: 0
+pin_memory: True
+gradient_checkpointing: True
+noise_to_first_frame: 0.0
+
+optimizer: adamw
+lr: 1e-5
+beta1: 0.9
+beta2: 0.95
+beta3: 0.999
+epsilon: 1e-8
+weight_decay: 1e-5
+optimizer_8bit: False
+optimizer_torchao: False
+scale_lr: False
+max_grad_norm: 1.0
+gradient_accumulation_steps: 1
+
+lr_scheduler: constant_with_warmup
+lr_warmup_steps: 1
+lr_num_cycles: 1
+lr_power: 1.0
+
+flow_weighting_scheme: none
+flow_logit_mean: 0.0
+flow_logit_std: 1.0
+flow_mode_scale: 1.29
+pixel_wise_timestep: False
+
+diffusion_model:
+  model_path: PATH_TO_GE_SIM_COSMOS_CHECKPOINT_SAFETENSOR
+  config:
+    in_channels: 26  # 16 (vae latent) + 3 (traj) + 6 (raymap) + 1 (condition mask); padding_mask is appended inside the transformer
+    out_channels: 16
+    num_attention_heads: 16
+    attention_head_dim: 128
+    num_layers: 28
+    mlp_ratio: 4.0
+    text_embed_dim: 1024
+    adaln_lora_dim: 256
+    max_size: [128, 240, 240]
+    patch_size: [1, 2, 2]
+    rope_scale: [1.0, 3.0, 3.0]
+    concat_padding_mask: true
+    extra_pos_embed_type: null
+    use_view_embed: true
+    action_expert: false
+    action_in_channels: 7
+    action_num_attention_heads: 16
+    action_attention_head_dim: 32
+    action_rope_dim: 32
+
+data:
+  train:
+    data_roots: ["path/to/AgiBotWorldChallenge-2026/WorldModel"]
+    domains: ["agibotworld"]
+    split: "train"
+    sample_size: [320, 512]
+    sample_n_frames: 20
+    preprocess: 'resize'
+    valid_cam: ['head']
+    chunk: 16
+    action_chunk: 16
+    n_previous: 4
+    previous_pick_mode: 'random'
+    random_crop: False
+    min_sep: 1
+    max_sep: 1
+    dataset_info_cache_path: null
+    use_unified_prompt: True
+    unified_prompt: "best quality, consistent and smooth motion, realistic, clear and distinct."
+    action_space: "eef"
+    normalize_actions: False
+    fix_epiidx: 0
+    fix_sidx: 4
+    fix_mem_idx: [0, 1, 2, 3]
+  val:
+    data_roots: ["path/to/AgiBotWorldChallenge-2026/WorldModel"]
+    domains: ["agibotworld"]
+    split: "train"
+    sample_size: [320, 512]
+    sample_n_frames: 20
+    preprocess: 'resize'
+    valid_cam: ['head']
+    chunk: 16
+    action_chunk: 16
+    n_previous: 4
+    previous_pick_mode: 'random'
+    random_crop: False
+    min_sep: 1
+    max_sep: 1
+    dataset_info_cache_path: null
+    use_unified_prompt: True
+    unified_prompt: "best quality, consistent and smooth motion, realistic, clear and distinct."
+    action_space: "eef"
+    normalize_actions: False
+    fix_epiidx: 0
+    fix_sidx: 4
+    fix_mem_idx: [0, 1, 2, 3]
+
+use_color_jitter: false
+num_inference_step: 5
+noisy_video: false
+load_weights: true
+use_deepspeed: false

--- a/data/challenge_wm_dataset.py
+++ b/data/challenge_wm_dataset.py
@@ -1,0 +1,380 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import json
+import random
+import traceback
+import warnings
+
+import h5py
+import numpy as np
+import torch
+import torchvision.transforms as transforms
+from moviepy.editor import VideoFileClip
+from torch.utils.data.dataset import Dataset
+
+from data.utils.domain_table import DomainTable
+from data.utils.get_actions import parse_h5
+from data.utils.statistics import StatisticInfo
+from data.utils.utils import gen_crop_config, intrin_crop_transform, intrinsic_transform
+from utils import zero_rank_print
+from utils.get_ray_maps import get_ray_maps
+from utils.get_traj_maps import get_traj_maps, simple_radius_gen_func
+
+warnings.filterwarnings("ignore", category=FutureWarning)
+
+
+class ChallengeWMDataset(Dataset):
+    def __init__(
+        self,
+        data_roots,
+        domains,
+        split="train",
+        sample_size=(320, 512),
+        sample_n_frames=64,
+        preprocess="resize",
+        valid_cam=("head",),
+        chunk=16,
+        action_chunk=None,
+        n_previous=4,
+        previous_pick_mode="random",
+        random_crop=True,
+        min_sep=1,
+        max_sep=3,
+        fps=2,
+        dataset_info_cache_path=None,
+        use_unified_prompt=True,
+        unified_prompt="best quality, consistent and smooth motion, realistic, clear and distinct.",
+        fix_epiidx=None,
+        fix_sidx=None,
+        fix_mem_idx=None,
+        action_space="eef",
+        normalize_actions=False,
+        stat_file=None,
+        radius_mode="simple",
+    ):
+        zero_rank_print("loading challenge wm annotations...")
+
+        if action_space != "eef":
+            raise ValueError("ChallengeWMDataset currently only supports eef action_space.")
+
+        if not isinstance(valid_cam, (list, tuple)):
+            valid_cam = [valid_cam]
+        if len(valid_cam) != 1:
+            raise ValueError("ChallengeWMDataset expects single-view input.")
+
+        self.valid_cam = list(valid_cam)
+        self.data_roots = data_roots
+        self.sample_size = sample_size
+        self.sample_n_frames = sample_n_frames
+        self.preprocess = preprocess
+        self.chunk = chunk
+        self.action_chunk = action_chunk or chunk
+        self.video_temporal_stride = self.action_chunk // self.chunk
+        if self.chunk * self.video_temporal_stride != self.action_chunk:
+            raise ValueError("action_chunk should be an integer multiple of chunk.")
+
+        self.n_previous = n_previous
+        self.previous_pick_mode = previous_pick_mode
+        self.random_crop = random_crop
+        self.min_sep = min_sep
+        self.max_sep = max_sep
+        self.fps = fps
+        self.use_unified_prompt = use_unified_prompt
+        self.unified_prompt = unified_prompt
+        self.fix_epiidx = fix_epiidx
+        self.fix_sidx = fix_sidx
+        self.fix_mem_idx = fix_mem_idx
+        self.action_space = action_space
+        self.normalize_actions = normalize_actions
+        self.radius_mode = radius_mode
+
+        if preprocess == "center_crop_resize":
+            self.pixel_transforms_resize = transforms.Compose(
+                [
+                    transforms.Resize(min(sample_size)),
+                    transforms.CenterCrop(sample_size),
+                ]
+            )
+        elif preprocess == "resize":
+            self.pixel_transforms_resize = transforms.Compose([transforms.Resize(sample_size)])
+        else:
+            raise NotImplementedError
+        self.pixel_transforms_norm = transforms.Compose(
+            [
+                transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5], inplace=True),
+            ]
+        )
+
+        self.StatisticInfo = StatisticInfo
+        if stat_file is not None:
+            with open(stat_file, "r") as f:
+                self.StatisticInfo = json.load(f)
+
+        self.dataset = []
+        if dataset_info_cache_path is not None and os.path.exists(dataset_info_cache_path):
+            zero_rank_print(f"Load cache dataset information from {dataset_info_cache_path}")
+            with open(dataset_info_cache_path, "r") as f:
+                self.dataset = json.load(f)
+        else:
+            for data_root, domain_name in zip(self.data_roots, domains):
+                split_root = os.path.join(data_root, split)
+                if not os.path.isdir(split_root):
+                    raise FileNotFoundError(f"Challenge WM split not found: {split_root}")
+
+                file_list = sorted(os.listdir(split_root))
+                for file_name in file_list:
+                    sample_root = os.path.join(split_root, file_name)
+                    if not os.path.isdir(sample_root):
+                        continue
+                    info = [
+                        sample_root,
+                        domain_name,
+                        DomainTable.get(domain_name, 0),
+                        file_name,
+                    ]
+                    self.dataset.append(info)
+
+            if dataset_info_cache_path is not None:
+                zero_rank_print(f"Save cache dataset information to {dataset_info_cache_path}")
+                cache_dir = os.path.dirname(dataset_info_cache_path)
+                if cache_dir:
+                    os.makedirs(cache_dir, exist_ok=True)
+                with open(dataset_info_cache_path, "w") as f:
+                    json.dump(self.dataset, f)
+
+        self.length = len(self.dataset)
+        zero_rank_print(f"challenge wm data scale: {self.length}")
+
+    def __len__(self):
+        return self.length
+
+    def get_total_timesteps(self, sample_root, cam_name):
+        with open(os.path.join(sample_root, f"{cam_name}_extrinsic_params_aligned.json"), "r") as f:
+            info = json.load(f)
+        return len(info)
+
+    def get_frame_indexes(self, total_frames, sep=1):
+        if self.fix_sidx is not None and self.fix_mem_idx is not None:
+            action_indexes = list(range(self.fix_sidx, self.fix_sidx + self.action_chunk))
+            frame_indexes = action_indexes[self.video_temporal_stride - 1 :: self.video_temporal_stride]
+            return self.fix_mem_idx + frame_indexes
+
+        if total_frames > self.action_chunk * sep:
+            chunk_end = random.randint(self.action_chunk * sep, total_frames)
+        else:
+            chunk_end = total_frames
+
+        indexes = np.array(list(range(chunk_end - self.sample_n_frames * sep, chunk_end, sep)))
+        indexes = np.clip(indexes, a_min=1, a_max=total_frames - 1).tolist()
+
+        video_end = indexes[-self.action_chunk :]
+        mem_candidates = indexes[: self.sample_n_frames - self.action_chunk]
+
+        if len(mem_candidates) == 0:
+            mem_candidates = [indexes[0]]
+
+        if self.previous_pick_mode == "uniform":
+            mem_indexes = [
+                mem_candidates[int(i)]
+                for i in np.linspace(0, len(mem_candidates) - 1, self.n_previous).tolist()
+            ]
+        elif self.previous_pick_mode == "random":
+            if len(mem_candidates) <= self.n_previous:
+                mem_indexes = mem_candidates[: self.n_previous]
+                while len(mem_indexes) < self.n_previous:
+                    mem_indexes.insert(0, mem_indexes[0])
+            else:
+                sampled = sorted(
+                    np.random.choice(
+                        list(range(0, len(mem_candidates) - 1)),
+                        size=self.n_previous - 1,
+                        replace=False,
+                    ).tolist()
+                )
+                mem_indexes = [mem_candidates[i] for i in sampled] + [mem_candidates[-1]]
+        else:
+            raise NotImplementedError(f"unsupported previous_pick_mode: {self.previous_pick_mode}")
+
+        frame_indexes = mem_indexes + video_end[self.video_temporal_stride - 1 :: self.video_temporal_stride]
+        return frame_indexes
+
+    def get_action_bias_std(self, domain_name, stat_key):
+        full_key = f"{domain_name}_{stat_key}"
+        if full_key not in self.StatisticInfo:
+            return None, None
+        info = self.StatisticInfo[full_key]
+        return (
+            torch.tensor(info["mean"], dtype=torch.float32).unsqueeze(0),
+            torch.tensor(info["std"], dtype=torch.float32).unsqueeze(0),
+        )
+
+    def get_action(self, h5_file, slices, domain_name):
+        delta_action = parse_h5(
+            h5_file,
+            slices=slices,
+            delta_act_sidx=self.n_previous,
+            action_space=self.action_space,
+        )[1]
+        delta_action = torch.FloatTensor(delta_action)
+
+        with h5py.File(h5_file, "r") as fid:
+            all_abs_gripper = np.array(fid["state/effector/position"], dtype=np.float32)
+            all_ends_p = np.array(fid["state/end/position"], dtype=np.float32)
+            all_ends_o = np.array(fid["state/end/orientation"], dtype=np.float32)
+
+        pose_action = []
+        for i in slices:
+            pose_action.append(
+                np.concatenate(
+                    (
+                        all_ends_p[i, 0],
+                        all_ends_o[i, 0],
+                        all_abs_gripper[i, :1],
+                        all_ends_p[i, 1],
+                        all_ends_o[i, 1],
+                        all_abs_gripper[i, 1:],
+                    ),
+                    axis=0,
+                )
+            )
+        action = torch.FloatTensor(np.stack(pose_action, axis=0))
+
+        if self.normalize_actions:
+            delta_mean, delta_std = self.get_action_bias_std(domain_name, f"delta_{self.action_space}")
+            if delta_mean is not None and delta_std is not None:
+                delta_action = (delta_action - delta_mean) / (delta_std + 1e-6)
+
+        return action, delta_action
+
+    def seek_mp4(self, sample_root, cam_name, slices):
+        video_reader = VideoFileClip(os.path.join(sample_root, f"{cam_name}_color.mp4"))
+        fps = video_reader.fps
+        video = []
+        for idx in slices:
+            video.append(video_reader.get_frame(float(idx) / fps))
+        video = torch.from_numpy(np.stack(video)).permute(3, 0, 1, 2).contiguous()
+        video = video.float() / 255.0
+        video_reader.close()
+        return video
+
+    def get_intrin_and_extrin(self, sample_root, cam_name, slices):
+        with open(os.path.join(sample_root, f"{cam_name}_intrinsic_params.json"), "r") as f:
+            info = json.load(f)["intrinsic"]
+        intrinsic = torch.eye(3, dtype=torch.float32)
+        intrinsic[0, 0] = info["fx"]
+        intrinsic[1, 1] = info["fy"]
+        intrinsic[0, 2] = info["ppx"]
+        intrinsic[1, 2] = info["ppy"]
+
+        with open(os.path.join(sample_root, f"{cam_name}_extrinsic_params_aligned.json"), "r") as f:
+            info = json.load(f)
+        c2ws = []
+        w2cs = []
+        for frame_idx in slices:
+            frame_info = info[frame_idx]
+            c2w = torch.eye(4, dtype=torch.float32)
+            c2w[:3, :3] = torch.FloatTensor(frame_info["extrinsic"]["rotation_matrix"])
+            c2w[:3, -1] = torch.FloatTensor(frame_info["extrinsic"]["translation_vector"])
+            c2ws.append(c2w)
+            w2cs.append(torch.linalg.inv(c2w))
+
+        return intrinsic, torch.stack(c2ws, dim=0), torch.stack(w2cs, dim=0)
+
+    def transform_video(self, video, intrinsic):
+        c, _, h, w = video.shape
+        if self.random_crop:
+            h_start, w_start, h_crop, w_crop = gen_crop_config(video)
+            video = video[:, :, h_start : h_start + h_crop, w_start : w_start + w_crop]
+            intrinsic = intrin_crop_transform(intrinsic, h_start, w_start)
+            h, w = h_crop, w_crop
+
+        intrinsic = intrinsic_transform(intrinsic, (h, w), self.sample_size, self.preprocess)
+        video = self.pixel_transforms_resize(video)
+        return video, intrinsic
+
+    def normalize_video(self, video):
+        return self.pixel_transforms_norm(video.permute(1, 0, 2, 3)).permute(1, 0, 2, 3)
+
+    def build_ray_maps(self, intrinsic, c2ws):
+        intrinsics = intrinsic.unsqueeze(0)
+        c2ws = c2ws.unsqueeze(0)
+        rays_o, rays_d = get_ray_maps(
+            intrinsics.unsqueeze(1).repeat(1, c2ws.shape[1], 1, 1).reshape(-1, 3, 3),
+            c2ws.reshape(-1, 4, 4),
+            self.sample_size[0],
+            self.sample_size[1],
+        )
+        rays = torch.cat((rays_o, rays_d), dim=-1).reshape(
+            intrinsics.shape[0], c2ws.shape[1], rays_o.shape[1], rays_o.shape[2], -1
+        )
+        return rays.permute(4, 0, 1, 2, 3).float()
+
+    def get_caption(self, sample_name):
+        if self.use_unified_prompt:
+            return self.unified_prompt
+        return f"world model prediction for {sample_name}"
+
+    def get_batch(self, idx):
+        sample_root, domain_name, domain_id, sample_name = self.dataset[idx]
+        cam_name = self.valid_cam[0]
+        h5_file = os.path.join(sample_root, "proprio_stats.h5")
+
+        total_frames = self.get_total_timesteps(sample_root, cam_name)
+        sep = random.randint(self.min_sep, self.max_sep)
+        frame_indexes = self.get_frame_indexes(total_frames, sep=sep)
+
+        action, delta_action = self.get_action(h5_file, frame_indexes, domain_name)
+        intrinsic, c2ws, w2cs = self.get_intrin_and_extrin(sample_root, cam_name, frame_indexes)
+
+        video = self.seek_mp4(sample_root, cam_name, frame_indexes)
+        video, intrinsic = self.transform_video(video, intrinsic)
+        video = self.normalize_video(video).unsqueeze(1)
+
+        radius_gen_func = simple_radius_gen_func if self.radius_mode == "simple" else None
+        traj = get_traj_maps(
+            action,
+            w2cs.unsqueeze(0),
+            c2ws.unsqueeze(0),
+            intrinsic.unsqueeze(0),
+            self.sample_size,
+            radius_gen_func=radius_gen_func,
+        )
+        traj = traj * 2.0 - 1.0
+        ray = self.build_ray_maps(intrinsic, c2ws)
+        cond_to_concat = torch.cat((traj, ray), dim=0)
+
+        state = action[self.n_previous - 1 : self.n_previous]
+        caption = self.get_caption(sample_name)
+
+        sample = dict(
+            video=video,
+            caption=caption,
+            actions=action,
+            state=state,
+            action=action,
+            delta_action=delta_action,
+            intrinsic=intrinsic.unsqueeze(0),
+            extrinsic=c2ws.unsqueeze(0),
+            traj=traj,
+            ray=ray,
+            cond_to_concat=cond_to_concat,
+            cond_id=-(self.n_previous + self.chunk),
+            path=sample_root,
+            domain_id=domain_id,
+            fps=self.fps,
+        )
+        return sample
+
+    def __getitem__(self, idx):
+        if self.fix_epiidx is not None:
+            idx = self.fix_epiidx
+
+        while True:
+            try:
+                return self.get_batch(idx)
+            except Exception:
+                traceback.print_exc()
+                idx = random.randint(0, self.length - 1)

--- a/runner/ge_inferencer.py
+++ b/runner/ge_inferencer.py
@@ -29,7 +29,15 @@ from diffusers.training_utils import (
 )
 
 # ----------------------------------------------------
-from utils.model_utils import load_condition_models, load_latent_models, load_vae_models, load_diffusion_model, count_model_parameters, unwrap_model
+from utils.model_utils import (
+    build_gesim_pipeline,
+    count_model_parameters,
+    load_condition_models,
+    load_diffusion_model,
+    load_latent_models,
+    load_vae_models,
+    unwrap_model,
+)
 
 # ----------------------------------------------------
 from torch.utils.tensorboard import SummaryWriter
@@ -199,8 +207,13 @@ class Inferencer:
 
         os.makedirs(model_save_dir,exist_ok=True)
 
-        pipe = self.pipeline_class(
-            self.scheduler, self.vae, self.text_encoder, self.tokenizer, self.diffusion_model
+        pipe = build_gesim_pipeline(
+            self.pipeline_class,
+            text_encoder=self.text_encoder,
+            tokenizer=self.tokenizer,
+            transformer=self.diffusion_model,
+            vae=self.vae,
+            scheduler=self.scheduler,
         )
 
         assert(self.args.return_action | self.args.return_video)

--- a/runner/ge_trainer.py
+++ b/runner/ge_trainer.py
@@ -43,7 +43,16 @@ from accelerate.utils import (
 )
 
 # ----------------------------------------------------
-from utils.model_utils import load_condition_models, load_latent_models, load_vae_models, load_diffusion_model, count_model_parameters, unwrap_model
+from utils.model_utils import (
+    build_gesim_pipeline,
+    compute_total_latent_frames,
+    count_model_parameters,
+    load_condition_models,
+    load_diffusion_model,
+    load_latent_models,
+    load_vae_models,
+    unwrap_model,
+)
 from utils.model_utils import forward_pass
 from utils.optimizer_utils import get_optimizer
 from utils.memory_utils import get_memory_statistics, free_memory
@@ -538,13 +547,21 @@ class Trainer:
                     mem = video[:,:,:mem_size]
                     future_video = video[:,:,mem_size:]
 
+                    geom_cond = None
+                    if getattr(self.args, "use_geom_condition", False):
+                        geom_condition_key = getattr(self.args, "geom_condition_key", "cond_to_concat")
+                        if geom_condition_key not in batch:
+                            raise KeyError(f"Missing geometry condition key in batch: {geom_condition_key}")
+                        geom_cond = batch[geom_condition_key].to(
+                            accelerator.device, dtype=weight_dtype
+                        ).contiguous()
+
                     if self.args.return_action:
                         future_video = future_video[:,:,:1].repeat(1,1,self.args.data['train']['chunk'],1,1)
 
                     # get the shape params
                     _, _, raw_frames, raw_height, raw_width = future_video.shape
 
-                    latent_frames = raw_frames // self.TEMPORAL_DOWN_RATIO + 1 + mem_size
                     latent_height = raw_height // self.SPATIAL_DOWN_RATIO
                     latent_width = raw_width // self.SPATIAL_DOWN_RATIO
 
@@ -558,6 +575,7 @@ class Trainer:
 
                     mem_latents = rearrange(mem_latents, '(b v m) (h w) c -> (b v) c m h w', b=batch_size, m=mem_size, h=latent_height)
                     future_video_latents = rearrange(future_video_latents, '(b v) (f h w) c -> (b v) c f h w',b=batch_size,h=latent_height,w=latent_width)
+                    latent_frames = compute_total_latent_frames(mem_size, future_video_latents)
                     latents = torch.cat((mem_latents, future_video_latents), dim=2)
 
                     video_attention_mask = None
@@ -664,6 +682,8 @@ class Trainer:
                         video_attention_mask=video_attention_mask,
                         history_action_state=act_state,
                         condition_mask=conditioning_mask,
+                        cond_to_concat=geom_cond,
+                        n_prev=mem_size,
                     )['latents']
 
                     if self.args.train_mode == 'all' or self.args.train_mode == 'video_only':
@@ -784,9 +804,13 @@ class Trainer:
 
         os.makedirs(model_save_dir,exist_ok=True)
 
-        pipe = self.pipeline_class(
-            self.scheduler, self.vae, self.text_encoder, self.tokenizer,
-            unwrap_model(accelerator, self.diffusion_model) if accelerator is not None else self.diffusion_model
+        pipe = build_gesim_pipeline(
+            self.pipeline_class,
+            text_encoder=self.text_encoder,
+            tokenizer=self.tokenizer,
+            transformer=unwrap_model(accelerator, self.diffusion_model) if accelerator is not None else self.diffusion_model,
+            vae=self.vae,
+            scheduler=self.scheduler,
         )
 
         batch = next(iter(self.val_dataloader))
@@ -802,6 +826,13 @@ class Trainer:
 
         image = rearrange(image, 'b c v t h w -> (b v) c t h w')
         num_denois_steps = self.args.num_inference_step
+        geom_cond = None
+        if getattr(self.args, "use_geom_condition", False):
+            geom_condition_key = getattr(self.args, "geom_condition_key", "cond_to_concat")
+            if geom_condition_key not in batch:
+                raise KeyError(f"Missing geometry condition key in validation batch: {geom_condition_key}")
+            geom_cond = batch[geom_condition_key][:batch_size].clone()
+            geom_cond = rearrange(geom_cond, 'b c v t h w -> (b v) c t h w')
 
         if self.args.return_action and getattr(self.args, "add_state", False):
             history_action_state = batch['state'][:batch_size]
@@ -811,35 +842,57 @@ class Trainer:
         else:
             history_action_state = None
 
-        preds = pipe.infer(
-            image=image,
-            prompt=prompt[:batch_size],
-            negative_prompt=negative_prompt,
-            num_inference_steps=num_denois_steps,
-            decode_timestep=0.03,
-            decode_noise_scale=0.025,
-            guidance_scale=1.0,
-            height=h,
-            width=w,
-            n_view=v,
-            return_action=self.args.return_action,
-            n_prev=self.args.data['train']['n_previous'],
-            chunk=(self.args.data['train']['chunk']-1)//self.TEMPORAL_DOWN_RATIO+1,
-            return_video=self.args.return_video,
-            noise_seed=42,
-            action_chunk=self.args.data['train']['action_chunk'],
-            history_action_state = history_action_state,
-            pixel_wise_timestep = self.args.pixel_wise_timestep,
-            n_chunk=n_chunk,
-            action_dim=self.args.diffusion_model["config"]["action_in_channels"] if self.args.return_action else None,
-        )[0]
+        if getattr(self.args, "use_geom_condition", False):
+            preds = pipe.infer(
+                video=image.permute(0, 2, 1, 3, 4),
+                cond_to_concat=geom_cond,
+                prompt=prompt[:batch_size],
+                negative_prompt=negative_prompt,
+                num_inference_steps=num_denois_steps,
+                guidance_scale=1.0,
+                height=h,
+                width=w,
+                n_view=v,
+                n_prev=self.args.data['train']['n_previous'],
+                num_frames=self.args.data['train']['chunk'],
+                merge_view_into_width=False,
+                output_type="pt",
+                postprocess_video=False,
+                show_progress=False,
+            )["frames"]
+        else:
+            preds = pipe.infer(
+                image=image,
+                prompt=prompt[:batch_size],
+                negative_prompt=negative_prompt,
+                num_inference_steps=num_denois_steps,
+                decode_timestep=0.03,
+                decode_noise_scale=0.025,
+                guidance_scale=1.0,
+                height=h,
+                width=w,
+                n_view=v,
+                return_action=self.args.return_action,
+                n_prev=self.args.data['train']['n_previous'],
+                chunk=(self.args.data['train']['chunk']-1)//self.TEMPORAL_DOWN_RATIO+1,
+                return_video=self.args.return_video,
+                noise_seed=42,
+                action_chunk=self.args.data['train']['action_chunk'],
+                history_action_state = history_action_state,
+                pixel_wise_timestep = self.args.pixel_wise_timestep,
+                n_chunk=n_chunk,
+                action_dim=self.args.diffusion_model["config"]["action_in_channels"] if self.args.return_action else None,
+            )[0]
 
         cap = 'Validation'
         fps = int(getattr(self.args, "basic_fps", 30) / (self.args.data['train']['action_chunk'] // self.args.data['train']['chunk']))
         save_video(rearrange(gt_video[0].data.cpu(), 'c v t h w -> c t h (v w)', v=n_view), os.path.join(model_save_dir, f'{cap}_gt.mp4'), fps=fps)
 
         if self.args.return_video:
-            video = preds['video'].data.cpu()
+            if getattr(self.args, "use_geom_condition", False):
+                video = preds.data.cpu()
+            else:
+                video = preds['video'].data.cpu()
             save_video(rearrange(video, '(b v) c t h w -> b c t h (v w)', v=n_view)[0], os.path.join(model_save_dir, f'{cap}.mp4'), fps=fps)
 
         if to_log:
@@ -860,4 +913,3 @@ class Trainer:
             if to_log:
                 for key, value in action_logs.items():
                     self.writer.add_scalar(key, value, global_step)
-

--- a/scripts/train_challenge_wm.sh
+++ b/scripts/train_challenge_wm.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_PATH=${1:-configs/cosmos_model/acwm_cosmos_challenge_wm_singleview.yaml}
+SCRIPT_PATH=${2:-main.py}
+
+bash "$(dirname "$0")/train.sh" "$SCRIPT_PATH" "$CONFIG_PATH"

--- a/tests/test_gesim_regressions.py
+++ b/tests/test_gesim_regressions.py
@@ -1,0 +1,66 @@
+import ast
+from pathlib import Path
+import unittest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODEL_UTILS_PATH = REPO_ROOT / "utils" / "model_utils.py"
+
+
+def load_function(function_name):
+    source = MODEL_UTILS_PATH.read_text()
+    module_ast = ast.parse(source)
+    for node in module_ast.body:
+        if isinstance(node, ast.FunctionDef) and node.name == function_name:
+            namespace = {}
+            function_module = ast.Module(body=[node], type_ignores=[])
+            ast.fix_missing_locations(function_module)
+            exec(compile(function_module, str(MODEL_UTILS_PATH), "exec"), namespace)
+            return namespace[function_name]
+    return None
+
+
+class RecorderPipeline:
+    def __init__(self, *args):
+        self.args = args
+
+
+class GeSimRegressionTests(unittest.TestCase):
+    def test_compute_total_latent_frames_uses_encoded_future_axis(self):
+        compute_total_latent_frames = load_function("compute_total_latent_frames")
+        self.assertIsNotNone(compute_total_latent_frames)
+
+        class DummyTensor:
+            shape = (2, 16, 3, 5, 7)
+            ndim = len(shape)
+
+        self.assertEqual(compute_total_latent_frames(4, DummyTensor()), 7)
+
+    def test_build_gesim_pipeline_matches_public_signature(self):
+        build_gesim_pipeline = load_function("build_gesim_pipeline")
+        self.assertIsNotNone(build_gesim_pipeline)
+
+        pipe = build_gesim_pipeline(
+            RecorderPipeline,
+            text_encoder="text",
+            tokenizer="tokenizer",
+            transformer="transformer",
+            vae="vae",
+            scheduler="scheduler",
+        )
+
+        self.assertEqual(pipe.args, ("text", "tokenizer", "transformer", "vae", "scheduler"))
+
+    def test_ge_trainer_uses_public_pipeline_builder_and_latent_frame_helper(self):
+        trainer_source = (REPO_ROOT / "runner" / "ge_trainer.py").read_text()
+
+        self.assertIn("compute_total_latent_frames", trainer_source)
+        self.assertIn("build_gesim_pipeline", trainer_source)
+
+    def test_ge_inferencer_uses_public_pipeline_builder(self):
+        inferencer_source = (REPO_ROOT / "runner" / "ge_inferencer.py").read_text()
+
+        self.assertIn("build_gesim_pipeline", inferencer_source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/model_utils.py
+++ b/utils/model_utils.py
@@ -7,7 +7,10 @@ import torch
 import torch.nn as nn
 from accelerate import Accelerator
 from diffusers.utils.torch_utils import is_compiled_module
+from einops import rearrange
 from safetensors.torch import save_model, load_file, save_file
+
+from utils.geometry_utils import resize_traj_and_ray
 
 
 def unwrap_model(accelerator: Accelerator, model):
@@ -160,6 +163,16 @@ def load_vae_models(model_cls, model_dir, load_weights=True):
     return model
 
 
+def compute_total_latent_frames(mem_size, future_video_latents):
+    if future_video_latents.ndim < 3:
+        raise ValueError("future_video_latents must include a latent-frame axis.")
+    return mem_size + future_video_latents.shape[2]
+
+
+def build_gesim_pipeline(pipeline_class, *, text_encoder, tokenizer, transformer, vae, scheduler):
+    return pipeline_class(text_encoder, tokenizer, transformer, vae, scheduler)
+
+
 def forward_pass(
     model,
     prompt_embeds: torch.Tensor,
@@ -177,6 +190,40 @@ def forward_pass(
 ) -> torch.Tensor:
     latent_frame_rate = frame_rate / temporal_compression_ratio
     rope_interpolation_scale = [1 / latent_frame_rate, spatial_compression_ratio, spatial_compression_ratio]
+
+    cond_to_concat = kwargs.pop("cond_to_concat", None)
+    n_prev = kwargs.get("n_prev")
+    condition_mask = kwargs.get("condition_mask")
+
+    if cond_to_concat is not None:
+        if n_prev is None:
+            raise ValueError("n_prev is required when cond_to_concat is provided.")
+
+        if cond_to_concat.ndim == 6:
+            cond_to_concat = rearrange(cond_to_concat, "b c v t h w -> (b v) c t h w")
+        elif cond_to_concat.ndim != 5:
+            raise ValueError(f"Unsupported cond_to_concat shape: {cond_to_concat.shape}")
+
+        if noisy_latents.ndim != 3:
+            raise ValueError("Geometry-conditioned training expects flattened noisy_latents.")
+
+        noisy_latents = rearrange(
+            noisy_latents,
+            "bv (t h w) c -> bv c t h w",
+            t=num_frames,
+            h=height,
+            w=width,
+        )
+        cond_to_concat = cond_to_concat.to(device=noisy_latents.device, dtype=noisy_latents.dtype)
+        cond_to_concat = resize_traj_and_ray(
+            cond_to_concat,
+            mem_size=n_prev,
+            future_size=num_frames - n_prev,
+            height=height,
+            width=width,
+        )
+        noisy_latents = torch.cat([noisy_latents, cond_to_concat], dim=1)
+        noisy_latents = rearrange(noisy_latents, "bv c t h w -> bv (t h w) c")
     
     denoised_latents = model(
         hidden_states=noisy_latents,


### PR DESCRIPTION
## Summary
- add a `ChallengeWMDataset` adapter and single-view GE-Sim configs for AgiBot World Model track finetuning
- wire GE-Sim geometry conditioning into training and validation, including `cond_to_concat` support in the training forward path
- fix GE-Sim pipeline construction order and latent frame counting to match the released public Cosmos GE-Sim weights
- add a lightweight regression test covering pipeline argument order and latent-frame handling

## Test Plan
- [x] `python3 -m unittest /Users/pencil/Documents/AGIBotCompetition/Genie-Envisioner/tests/test_gesim_regressions.py -v`
- [x] `python3 -m py_compile /Users/pencil/Documents/AGIBotCompetition/Genie-Envisioner/utils/model_utils.py /Users/pencil/Documents/AGIBotCompetition/Genie-Envisioner/runner/ge_trainer.py /Users/pencil/Documents/AGIBotCompetition/Genie-Envisioner/runner/ge_inferencer.py /Users/pencil/Documents/AGIBotCompetition/Genie-Envisioner/data/challenge_wm_dataset.py /Users/pencil/Documents/AGIBotCompetition/Genie-Envisioner/tests/test_gesim_regressions.py`
- [ ] Full WM training run on Linux + NVIDIA environment
